### PR TITLE
Add eval command for string evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Requires Zig 0.13.0 or later.
 zig build && zig-out/bin/gene run examples/default.gene
 zig build -Ddebug=true && zig-out/bin/gene run examples/default.gene
 zig build run -- run examples/default.gene
+zig build run -- eval "(print (1 + 2))"
 
 # Run tests
 zig build test

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@ fn printHelp(writer: anytype) !void {
     try writer.print("  run       Run a Gene source file\n", .{});
     try writer.print("  compile   Compile a Gene source file\n", .{});
     try writer.print("  repl      Start the Gene REPL\n", .{});
+    try writer.print("  eval      Evaluate a Gene expression string\n", .{});
     try writer.print("  help      Show this help message\n", .{});
     try writer.print("  version   Show the current version\n", .{});
     try writer.print("\nOptions:\n", .{});
@@ -62,6 +63,17 @@ pub fn main() !void {
         defer rt.deinit();
 
         try rt.compileFile(file);
+    } else if (std.mem.eql(u8, command, "eval")) {
+        if (args.len < 3) {
+            std.debug.print("Usage: gene eval <source> [--debug]\n", .{});
+            return;
+        }
+
+        const source = args[2];
+        var rt = runtime.Runtime.init(allocator, debug_mode, std.io.getStdOut().writer());
+        defer rt.deinit();
+
+        try rt.eval(source);
     } else if (std.mem.eql(u8, command, "repl")) {
         var rt = runtime.Runtime.init(allocator, debug_mode, std.io.getStdOut().writer());
         defer rt.deinit();


### PR DESCRIPTION
## Summary
- add new `eval` command to CLI
- document `eval` usage in README

## Testing
- `zig build test` *(fails: `zig: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68478d2f96bc832faabf8d0fdbb60ce5