### PR TITLE
Refactor parser API to return nodes directly

### DIFF
--- a/src/frontend/parser.zig
+++ b/src/frontend/parser.zig
@@ -240,22 +240,14 @@ fn isBinaryOperator(op_str: []const u8) bool {
 ///     parse_result.arena.deinit();
 /// }
 /// ```
-// Simple tuple return - avoiding complex structs
-pub const ArenaAndCount = struct {
+pub const ParseSourceResult = struct {
     arena: *std.heap.ArenaAllocator,
-    node_count: usize,
+    nodes: []ast.AstNode,
 };
 
-// Global to store most recent parse result - simple approach to avoid complex returns
-var g_last_nodes: ?[]ast.AstNode = null;
-
-// Get the nodes from the last parse - call immediately after parseGeneSource
-pub fn getLastParseNodes() ?[]ast.AstNode {
-    return g_last_nodes;
-}
-
-// Return arena pointer and count - this should avoid the bus error
-pub fn parseGeneSource(parent_allocator: std.mem.Allocator, source: []const u8) !ArenaAndCount {
+/// Parse Gene source code using an arena allocator and return the arena
+/// along with the parsed nodes.
+pub fn parseGeneSource(parent_allocator: std.mem.Allocator, source: []const u8) !ParseSourceResult {
     // Create an arena allocator for all AST allocations
     const arena = try parent_allocator.create(std.heap.ArenaAllocator);
     arena.* = std.heap.ArenaAllocator.init(parent_allocator);
@@ -311,13 +303,10 @@ pub fn parseGeneSource(parent_allocator: std.mem.Allocator, source: []const u8) 
         nodes_slice[i] = node;
     }
 
-    // Store in global for retrieval
-    g_last_nodes = nodes_slice;
-
-    debug.log("parseGeneSource: returning arena and count", .{});
-    return ArenaAndCount{
+    debug.log("parseGeneSource: returning arena and nodes", .{});
+    return ParseSourceResult{
         .arena = arena,
-        .node_count = result_nodes.items.len,
+        .nodes = nodes_slice,
     };
 }
 

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -37,13 +37,7 @@ pub const CompiledResult = struct {
 pub fn compileSource(allocator: std.mem.Allocator, source: []const u8, options: compiler.CompilerOptions) !CompiledResult {
     // Parse source into AST
     const parse_result = try parser.parseGeneSource(allocator, source);
-
-    // Get the parsed nodes
-    const nodes = parser.getLastParseNodes() orelse {
-        parse_result.arena.deinit();
-        allocator.destroy(parse_result.arena);
-        return error.NoNodesReturned;
-    };
+    const nodes = parse_result.nodes;
 
     // Compile nodes to bytecode
     const ctx = compiler.CompilationContext.init(allocator, options);

--- a/src/tests/ast_to_hir_tests.zig
+++ b/src/tests/ast_to_hir_tests.zig
@@ -18,7 +18,7 @@ test "lower simple expression to HIR" {
     }
 
     // Lower to HIR
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     var hir_module = try ast_to_hir.convert(allocator, ast_nodes);
     defer hir_module.deinit();
 
@@ -60,7 +60,7 @@ test "lower binary operation to HIR" {
     }
 
     // Lower to HIR
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     var hir_module = try ast_to_hir.convert(allocator, ast_nodes);
     defer hir_module.deinit();
 
@@ -104,7 +104,7 @@ test "lower infix notation to HIR" {
     }
 
     // Lower to HIR
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     var hir_module = try ast_to_hir.convert(allocator, ast_nodes);
     defer hir_module.deinit();
 

--- a/src/tests/bytecode_tests.zig
+++ b/src/tests/bytecode_tests.zig
@@ -22,7 +22,7 @@ test "compile simple expression to bytecode" {
     }
 
     // Lower to HIR
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     var hir_module = try ast_to_hir.convert(allocator, ast_nodes);
     defer hir_module.deinit();
 
@@ -70,7 +70,7 @@ test "compile binary operation to bytecode" {
     }
 
     // Lower to HIR
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     var hir_module = try ast_to_hir.convert(allocator, ast_nodes);
     defer hir_module.deinit();
 

--- a/src/tests/parser_tests.zig
+++ b/src/tests/parser_tests.zig
@@ -15,7 +15,7 @@ test "parse string literal" {
         allocator.destroy(parse_result.arena);
     }
 
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     try testing.expectEqual(@as(usize, 1), ast_nodes.len);
 
     const node = ast_nodes[0];
@@ -47,7 +47,7 @@ test "parse integer literal" {
         allocator.destroy(parse_result.arena);
     }
 
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     try testing.expectEqual(@as(usize, 1), ast_nodes.len);
 
     const node = ast_nodes[0];
@@ -79,7 +79,7 @@ test "parse binary operation" {
         allocator.destroy(parse_result.arena);
     }
 
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     try testing.expectEqual(@as(usize, 1), ast_nodes.len);
 
     const node = ast_nodes[0];
@@ -121,7 +121,7 @@ test "parse infix notation" {
         allocator.destroy(parse_result.arena);
     }
 
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     try testing.expectEqual(@as(usize, 1), ast_nodes.len);
 
     const node = ast_nodes[0];
@@ -161,7 +161,7 @@ test "parse function definition" {
         allocator.destroy(parse_result.arena);
     }
 
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     try testing.expectEqual(@as(usize, 1), ast_nodes.len);
 
     const node = ast_nodes[0];
@@ -192,7 +192,7 @@ test "parse fibonacci example" {
     }
 
     // Expecting 3 top-level nodes: fn definition, var declaration, print expression
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
     try testing.expectEqual(@as(usize, 3), ast_nodes.len);
 
     // TODO: Add more specific assertions about the parsed nodes if needed

--- a/src/tests/vm_tests.zig
+++ b/src/tests/vm_tests.zig
@@ -22,7 +22,7 @@ fn testGeneExecution(source: []const u8, expected: types.Value) !void {
     }
 
     // Use the proper compilation pipeline
-    const ast_nodes = parser.getLastParseNodes() orelse return error.NoAstNodesFound;
+    const ast_nodes = parse_result.nodes;
 
     // Convert AST to HIR
     var hir_module = try ast_to_hir.convert(allocator, ast_nodes);


### PR DESCRIPTION
## Summary
- change `parseGeneSource` to return a `ParseSourceResult` struct containing the arena and node slice
- remove `g_last_nodes` global and `getLastParseNodes`
- update `pipeline.compileSource` and all tests to use the returned slice

## Testing
- `zig build test` *(fails: `zig: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847902966a0832f963341d2583b48fd