### PR TITLE
Add stdin support for Gene CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ zig build run -- eval "(print (1 + 2))"
 
 # Run tests
 zig build test
+
+# Read code from stdin
+echo '(print "Hello")' | zig-out/bin/gene run -
+echo '(+ 1 2)' | zig-out/bin/gene eval -
+echo '(print "hi")' | zig-out/bin/gene compile -
 ```
 
 ## WebAssembly Support
@@ -67,6 +72,8 @@ Gene syntax can also be used as a data format similar to JSON or YAML. Use the `
 # Parse from stdin
 echo '(config ^version "1.0" ^debug true)' | ./zig-out/bin/gene parse -
 ```
+
+`gene run -`, `gene compile -` and `gene eval -` accept code from stdin in the same way.
 
 Gene data format supports:
 - Basic types: integers, floats, booleans, strings, nil

--- a/testsuite/run_tests.sh
+++ b/testsuite/run_tests.sh
@@ -86,6 +86,33 @@ for category in basics control_flow functions data_structures oop arithmetic str
     fi
 done
 
+# Test stdin features
+echo "--- stdin ---"
+if echo '(print 7)' | $GENE run - | grep -q 7; then
+    echo -e "${GREEN}PASS${NC} run_stdin"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}FAIL${NC} run_stdin"
+    FAILED=$((FAILED + 1))
+fi
+
+if echo '(+ 2 3)' | $GENE eval - | grep -q 5; then
+    echo -e "${GREEN}PASS${NC} eval_stdin"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}FAIL${NC} eval_stdin"
+    FAILED=$((FAILED + 1))
+fi
+
+if echo '(print 1)' | $GENE compile - > /dev/null && [ -f stdin.gbc ] && $GENE run stdin.gbc | grep -q 1; then
+    echo -e "${GREEN}PASS${NC} compile_stdin"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}FAIL${NC} compile_stdin"
+    FAILED=$((FAILED + 1))
+fi
+rm -f stdin.gbc
+
 # Run data parser tests if available
 if [ -x "data_parser/run_tests.sh" ]; then
     echo "--- data_parser ---"


### PR DESCRIPTION
## Summary
- support piping source into `gene run`, `gene compile` and `gene eval`
- add `Runtime.runSource` and `Runtime.compileSource`
- fix ArrayList usage after Zig update
- document piping in README
- test running, compiling and eval from stdin

## Testing
- `./test.sh` *(fails: UnsupportedInstruction)*

------
https://chatgpt.com/codex/tasks/task_e_684d9b361530832f82796fded04f7bea